### PR TITLE
Handle missing modules

### DIFF
--- a/src/abstk.lua
+++ b/src/abstk.lua
@@ -8,8 +8,22 @@
 
 local abstk = {}
 
-local AbsGtk = require 'abstk.AbsGtk'
-local AbsCurses = require 'abstk.AbsCurses'
+local AbsGtk
+local AbsCurses
+
+do
+   local okay,mod
+  
+   okay,mod = pcall(require,'abstk.AbsGtk')
+   if okay then
+     AbsGtk = mod
+   end
+  
+   okay,mod = pcall(require,'abstk.AbsCurses')
+   if okay then
+     AbsCurses = mod
+   end
+end
 
 local mode = nil
 
@@ -24,7 +38,7 @@ local mode = nil
 function abstk.set_mode(arg)
    if arg == 'curses' or arg == 'gtk' then
       mode = arg
-   elseif os.getenv("DISPLAY") then
+   elseif os.getenv("DISPLAY") and AbsGtk then
       mode = 'gtk'
    else
       mode = 'curses'

--- a/src/abstk.lua
+++ b/src/abstk.lua
@@ -12,17 +12,10 @@ local AbsGtk
 local AbsCurses
 
 do
-   local okay,mod
-  
-   okay,mod = pcall(require,'abstk.AbsGtk')
-   if okay then
-     AbsGtk = mod
-   end
-  
-   okay,mod = pcall(require,'abstk.AbsCurses')
-   if okay then
-     AbsCurses = mod
-   end
+   local has_gtk, gtk_module = pcall(require,'abstk.AbsGtk')
+   local has_curses, curses_module = pcall(require,'abstk.AbsCurses')
+   if has_gtk then AbsGtk = gtk_module end
+   if has_curses then AbsCurses = curses_module end
 end
 
 local mode = nil

--- a/src/abstk/AbsCurses.lua
+++ b/src/abstk/AbsCurses.lua
@@ -10,9 +10,12 @@
 local utf8
 
 if _VERSION < "Lua 5.3" then
-  utf8 = { len = string.len }
+   local has_dep, utf8 = pcall(require, 'lua-utf8')
+   if not has_dep then
+      utf8 = { len = string.len }
+   end
 else
-  utf8 = require "utf8"
+   utf8 = require 'utf8'
 end
 
 local AbsCurses = {}

--- a/src/abstk/AbsCurses.lua
+++ b/src/abstk/AbsCurses.lua
@@ -7,6 +7,14 @@
 -- @see abstk
 -------------------------------------------------
 
+local utf8
+
+if _VERSION < "Lua 5.3" then
+  utf8 = { len = string.len }
+else
+  utf8 = require "utf8"
+end
+
 local AbsCurses = {}
 
 local curses = require 'curses'

--- a/src/abstk/util.lua
+++ b/src/abstk/util.lua
@@ -8,6 +8,14 @@
 -- @see AbsGtk
 -------------------------------------------------
 
+local utf8
+
+if _VERSION < "Lua 5.3" then
+  utf8 = { len = string.len }
+else
+  utf8 = require "utf8"
+end
+
 local util = {}
 
 function util.make_list_items(make_item, list, default_value)

--- a/src/abstk/util.lua
+++ b/src/abstk/util.lua
@@ -11,9 +11,12 @@
 local utf8
 
 if _VERSION < "Lua 5.3" then
-  utf8 = { len = string.len }
+   local has_dep, utf8 = pcall(require, 'lua-utf8')
+   if not has_dep then
+      utf8 = { len = string.len }
+   end
 else
-  utf8 = require "utf8"
+   utf8 = require 'utf8'
 end
 
 local util = {}


### PR DESCRIPTION
Not everyone using X Windows uses GTK (nor wants it).  To help support these
people, protect the call to 'require "abstk.AbsGtk"' to allow it to fail
without aborting the program.

Do the same with those that want to use GTK, but don't want to bother with
the Curses interface, just to be consistent.

Also involved are changes to support this module under Lua 5.1/5.2.  It's hack as it uses string.len() for utf8.len() but at least it will run (sigh---github failure here to separate these two changes) 