### PR TITLE
Specified that the version of gtk is 3.0 in src/abstk/AbsGtk.lua:13

### DIFF
--- a/src/abstk/AbsGtk.lua
+++ b/src/abstk/AbsGtk.lua
@@ -10,7 +10,7 @@
 local AbsGtk = {}
 
 local lgi = require 'lgi'
-local Gtk = lgi.require('Gtk')
+local Gtk = lgi.require('Gtk', '3.0')
 local util = require 'abstk.util'
 
 local Screen = {}


### PR DESCRIPTION
Коммитер:  jodros <15092760+jodros@users.noreply.github.com>

It was not opening the GTK mode until I specified the version...